### PR TITLE
Consolidation

### DIFF
--- a/group_list_modified.md
+++ b/group_list_modified.md
@@ -562,13 +562,13 @@ Wayland/Utils
 
 Window Manager ()
 
+Window Manager/Bar (Things like quickshell, waybar, ironbar, polybar)
+
 Window Manager/Display Manager ()
 
 Window Manager/Hyprland ()
 
 Window Manager/Hyprland/Wayland (place holder)
-
-Window Manager/Hyprland/NWG (?)
 
 Window Manager/Icewm ()
 

--- a/group_list_modified.md
+++ b/group_list_modified.md
@@ -6,8 +6,6 @@ Creation Date: 2025-03-24
 
 Accessibility
 
-Application,KDE,Qt,Utility
-
 Applications/Communications
 
 Applications/Desktop
@@ -38,14 +36,6 @@ Audio
 
 Backup
 
-Books/Computer books
-
-Books/Howtos
-
-Books/Literature
-
-Books/Other
-
 Communications
 
 Communications/Bluetooth
@@ -54,13 +44,7 @@ Communications/Radio
 
 Communications/Telephony
 
-COSMIC
-
 Databases
-
-Desktop/COSMIC
-
-Desktop/WM
 
 development
 
@@ -164,19 +148,7 @@ Development/Vala
 
 Development/X11
 
-Documentation
-
-Documentation/HTML
-
-Documentation/Other
-
 Drivers
-
-Editors
-
-Editors/Enlightenment
-
-Editors/GNOME
 
 Education
 
@@ -526,13 +498,13 @@ System/X11/Utilities/NWG
 
 System/X11/Wayland
 
-Terminal
+Terminal ()
 
-Terminal/Audio
+Terminal/Audio ()
 
-Terminals
+Terminal/Editors ()
 
-Text/Editors
+Terminals ()
 
 Text tools
 
@@ -572,24 +544,24 @@ Video/Television
 
 Video/Utilities
 
-Wallpapers/COSMIC
-
 Wayland
 
 Wayland/Utils
 
-WM/NWG
+Window Manager ()
 
-Window Manager
+Window Manager/Display Manager ()
 
-Window Manager/Hyprland
+Window Manager/Hyprland ()
 
 Window Manager/Hyprland/Wayland (place holder)
 
-Window Manager/Hyprland/NWG
+Window Manager/Hyprland/NWG (?)
 
-Window Manager/Icewm
+Window Manager/Icewm ()
 
-Window Manager/Wayland Utilities
+Window Manager/Miracle ()
 
-Window Manager/Wayfire
+Window Manager/Wayland Utilities (?)
+
+Window Manager/Wayfire ()

--- a/group_list_modified.md
+++ b/group_list_modified.md
@@ -230,8 +230,6 @@ Graphical Desktop/COSMIC/Utility ()
 
 Graphical Desktop/Enlightenment ()
 
-Graphical Desktop/FVWM based
-
 Graphical Desktop/GNOME ()
 
 Graphical Desktop/KDE ()
@@ -528,10 +526,6 @@ User interface/Desktops
 
 User Interface/Desktops
 
-Utilites
-
-Utilities
-
 Utility
 
 Utility/Stress Test
@@ -565,6 +559,8 @@ Window Manager ()
 Window Manager/Bar (Things like quickshell, waybar, ironbar, polybar)
 
 Window Manager/Display Manager ()
+
+Window Manager/FVWM based
 
 Window Manager/Hyprland ()
 

--- a/group_list_modified.md
+++ b/group_list_modified.md
@@ -6,6 +6,8 @@ Creation Date: 2025-03-24
 
 Accessibility
 
+                                      # Application Root Purpose: ??
+
 Applications/Communications
 
 Applications/Desktop
@@ -24,6 +26,8 @@ Applications/System
 
 Applications/Video
 
+                                      #Archiving Root Purpose: Holds programs related to creating or extracting archives
+
 Archiving/Backup
 
 Archiving/Cd burning
@@ -32,9 +36,13 @@ Archiving/Compression
 
 Archiving/Other
 
+                                      #Audio Root Purpose:
+
 Audio
 
 Backup
+
+                                      #Communications Root Purpose:
 
 Communications
 
@@ -46,7 +54,7 @@ Communications/Telephony
 
 Databases
 
-development
+                                      #DevelopmentRoot Purpose: Holds programs generally with a -devel ending
 
 Development
 
@@ -154,17 +162,13 @@ Education
 
 Embedded
 
-Emulator/Games
-
-Emulators
-
-Emulators/Games
-
 Extra
 
 File tools
 
 Fonts
+
+                                      #Games Root Purpose: Holds programs that are either games or have a game focus (not wine but proton)
 
 Games
 
@@ -177,6 +181,8 @@ Games/Arcade
 Games/Boards
 
 Games/Cards
+
+Games/Emulators ()
 
 Games/FPS
 
@@ -199,6 +205,8 @@ Games/Sports
 Games/Strategy
 
 Geography
+
+                                      #Graphical Desktop Root Purpose: Holds programs that made and maintained as a package deal for the Desktop Environment 
 
 Graphical Desktop ()
 
@@ -271,6 +279,8 @@ Internet/Web browser
 Libraries
 
 Monitoring
+
+                                      #Multimedia Root Purpose: Potentially holding codec 
 
 Multimedia
 
@@ -366,6 +376,8 @@ Servers/Groupware
 
 Shells
 
+                                      #Sound Root Purpose:
+
 Sound
 
 Sound/Editors and Converters
@@ -406,8 +418,6 @@ System/Configuration/Printing
 
 System/Configuration/ROCm
 
-System/Deepin
-
 System/Emulators/Other
 
 System/Emulators/PC
@@ -442,13 +452,9 @@ System/GUI/Wayland
 
 System/Hardware
 
-System/Hyprland
-
 System/Internationalization
 
 System/Kernel and hardware
-
-system/libraries
 
 System/Libraries
 
@@ -457,8 +463,6 @@ System/Libraries/C
 System/Libraries/C_C++
 
 System/Libraries/Cinnamon
-
-System/libraries/games
 
 System/Libraries/Wayfire
 
@@ -498,6 +502,8 @@ System/X11/Utilities/NWG
 
 System/X11/Wayland
 
+                                      #Terminal Root Purpose: Holding programs that usually are standalone and interact purely through the terminal (nano, vi, others)
+
 Terminal ()
 
 Terminal/Audio ()
@@ -528,9 +534,9 @@ Utilities
 
 Utility
 
-Utility/Hyprland
-
 Utility/Stress Test
+
+                                      #Video Root Purpose:
 
 Video
 
@@ -544,9 +550,15 @@ Video/Television
 
 Video/Utilities
 
+                                      #Virtualization Root Purpose: Holds programs that virtualize environments (qemu, virtualbox, or docker)
+
+Virtualization ()
+
 Wayland
 
 Wayland/Utils
+
+                                      #Window Manager Root Purpose: Holds programs that are part of window manager releases or are not shipped with a desktop environment or would be usable with one (swww wallpaper manager or waybar)
 
 Window Manager ()
 


### PR DESCRIPTION
I believe it would be in our best interest to put all documents in the documentation group and create subgroups for major docs to split up C docs from the system docs like systemd. I also remove some redundant groups. 